### PR TITLE
Add lower and upper cutoff support for bond matrix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,5 @@ GitHub.sublime-settings
 .history
 .DS_Store
 send.sh
+.worktrees/
+.artifacts/

--- a/pysktb/structure.py
+++ b/pysktb/structure.py
@@ -5,9 +5,23 @@ from .atom import Atom
 
 
 class Structure(object):
-    """Object to represent structure of system"""
+    """Object to represent structure of system
 
-    def __init__(self, lattice, atoms, periodicity=None, name=None, bond_cut=None, numba=True):
+    Args:
+        lattice: Lattice object defining the crystal structure
+        atoms: List of Atom objects
+        periodicity: List of 3 booleans for periodic boundary conditions (default: [True, True, True])
+        name: Name of the structure (default: "system")
+        bond_cut: Dictionary defining bond cutoffs. Two formats supported:
+            - Legacy format: {'XX': {'NN': value}} where XX is element pair and value is max cutoff
+            - New format: {'XX': {'min': lower, 'max': upper}} for min/max distance cutoffs
+            Bonds are included when min <= distance < max (or distance < NN for legacy format)
+        numba: Whether to use numba acceleration (default: True)
+    """
+
+    def __init__(
+        self, lattice, atoms, periodicity=None, name=None, bond_cut=None, numba=True
+    ):
         assert isinstance(lattice, Lattice), "not Lattice object"
         assert isinstance(atoms, list), "atoms is not list"
         assert isinstance(atoms[0], Atom), "atom is not Atom object"
@@ -26,13 +40,13 @@ class Structure(object):
 
     def get_supercell(self, sc, vac=[0, 0, 0]):
         """
-		 Input-
-		 sc:super cell lattice 3x3 
-		 vaccume: 1x3
-		 returns: pymatgen structure
-		 
-		 usefull for making use of pymatgen's codes for making finite complex slabs and defects
-		"""
+        Input-
+        sc:super cell lattice 3x3
+        vaccume: 1x3
+        returns: pymatgen structure
+
+        usefull for making use of pymatgen's codes for making finite complex slabs and defects
+        """
         try:
             import pymatgen as p
         except:
@@ -50,13 +64,25 @@ class Structure(object):
             l = p.core.lattice.Lattice.from_parameters(
                 a=abc[0], b=abc[1], c=abc[2], alpha=ang[0], beta=ang[1], gamma=ang[2]
             )
-            return p.Structure(lattice=l, species=new_s.species, coords=new_s.frac_coords)
+            return p.Structure(
+                lattice=l, species=new_s.species, coords=new_s.frac_coords
+            )
 
         final = get_vaccume(new_s, vac)
         return final
 
     def get_bond_mat(self):
-        """return bond matrix"""
+        """Return bond matrix.
+
+        Determines bonds based on distance cutoffs. Supports two bond_cut formats:
+        - Legacy: {'XX': {'NN': max_value}} - bonds included when distance < max_value
+        - Min/Max: {'XX': {'min': lower, 'max': upper}} - bonds included when min <= distance < max
+
+        Atoms always exclude themselves (distance = 0) regardless of min value.
+
+        Returns:
+            numpy.ndarray: Boolean array of shape (max_image, n_atom, n_atom) indicating bonds
+        """
 
         def get_cutoff(atom_1, atom_2):
             ele_1 = atom_1.element
@@ -69,6 +95,27 @@ class Structure(object):
             else:
                 return None
             return self.bond_cut[pair]
+
+        def get_min_max(cutoff_dict):
+            """Extract min and max cutoffs from cutoff dictionary.
+
+            Supports both legacy {'NN': value} and new {'min': x, 'max': y} formats.
+            Returns (min_cutoff, max_cutoff) tuple.
+            """
+            if cutoff_dict is None:
+                return (None, None)
+
+            # Check for new min/max format
+            if "min" in cutoff_dict or "max" in cutoff_dict:
+                min_cutoff = cutoff_dict.get("min", 0.0)
+                max_cutoff = cutoff_dict.get("max", float("inf"))
+                return (min_cutoff, max_cutoff)
+
+            # Legacy format: {'NN': value}
+            if "NN" in cutoff_dict:
+                return (0.0, cutoff_dict["NN"])
+
+            return (None, None)
 
         max_image = self.max_image
         n_atom = len(self.atoms)
@@ -85,10 +132,15 @@ class Structure(object):
         for image_i, image in enumerate(itertools.product(*periodic_image)):
             for i, atom1 in enumerate(atoms):
                 for j, atom2 in enumerate(atoms):
-                    cutoff = get_cutoff(atom1, atom2)["NN"]
-                    if cutoff is None:
+                    cutoff_dict = get_cutoff(atom1, atom2)
+                    min_cutoff, max_cutoff = get_min_max(cutoff_dict)
+                    if min_cutoff is None or max_cutoff is None:
                         continue
-                    bond_mat[image_i, i, j] = dist_mat[image_i, i, j] < cutoff
+                    distance = dist_mat[image_i, i, j]
+                    # Bond exists when min <= distance < max
+                    bond_mat[image_i, i, j] = (distance >= min_cutoff) and (
+                        distance < max_cutoff
+                    )
         bond_mat_2 = dist_mat > 0
 
         return bond_mat * bond_mat_2
@@ -110,10 +162,10 @@ class Structure(object):
         """return distance matrix vector"""
 
         def get_dist_vec(pos1, pos2, lat_vecs, l_min=False):
-            """ # p1, p2 direct 
-				# return angstrom
-				# latConst is included in lat_vecs
-			"""
+            """# p1, p2 direct
+            # return angstrom
+            # latConst is included in lat_vecs
+            """
             diff = np.array(pos1) - np.array(pos2)
             if np.linalg.norm(diff) == 0:
                 return 0
@@ -153,7 +205,9 @@ class Structure(object):
         """read POSCAR file and return Structure object (NOT SUPPORTED YET)"""
         # TODO: add support for POSCAR Files
         raise NotImplementedError
-        lat_const, lattice_mat, atom_set_direct, dynamics = readPOSCAR(fileName=file_name)
+        lat_const, lattice_mat, atom_set_direct, dynamics = readPOSCAR(
+            fileName=file_name
+        )
 
         atoms = []
         for a in atom_set_direct:
@@ -166,7 +220,7 @@ class Structure(object):
         return structure
 
     def get_dir_cos(self, image_i, atoms_i, atom_j):
-        """ return directional cos of distance vector """
+        """return directional cos of distance vector"""
         dist_vec = self.dist_mat_vec[image_i, atoms_i, atom_j, :]
         if np.linalg.norm(dist_vec) == 0:
             return 0, 0, 0
@@ -180,4 +234,3 @@ class Structure(object):
         indx_zero = np.where(dist_norm == 0)
         dist_norm[indx_zero] = 1e-10
         return dist_vec / dist_norm[:, :, :, np.newaxis]
-

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -1,0 +1,142 @@
+import pytest
+import numpy as np
+from pysktb.lattice import Lattice
+from pysktb.atom import Atom
+from pysktb.structure import Structure
+
+
+class TestBondCutoffBackwardCompatibility:
+    """Test backward compatibility with 'NN' format"""
+
+    def test_backward_compatibility_nn_format(self):
+        """AC1: Existing code using {'XX': {'NN': value}} format continues to work"""
+        # Create simple cubic lattice with a=3.0
+        lattice_matrix = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
+        lattice = Lattice(lattice_matrix, 3.0)
+
+        # Create two carbon atoms at distance ~1.5 (in fractional coords: 0.5 apart = 1.5 angstrom)
+        atom1 = Atom("C", [0.0, 0.0, 0.0])
+        atom2 = Atom("C", [0.5, 0.0, 0.0])
+        atoms = [atom1, atom2]
+
+        # Use old NN format
+        bond_cut = {"CC": {"NN": 3.0}}
+        structure = Structure(lattice, atoms, bond_cut=bond_cut)
+
+        # Assert bond_mat is not None and has expected shape
+        assert structure.bond_mat is not None
+        assert isinstance(structure.bond_mat, np.ndarray)
+        # Bonds should exist since distance (1.5) < cutoff (3.0)
+        assert np.any(structure.bond_mat == True)
+
+
+class TestBondCutoffMinMaxFormat:
+    """Test new min/max format support"""
+
+    def test_min_max_format_accepted(self):
+        """AC2: bond_cut accepts {'XX': {'min': lower, 'max': upper}} format"""
+        lattice_matrix = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
+        lattice = Lattice(lattice_matrix, 3.0)
+
+        atom1 = Atom("C", [0.0, 0.0, 0.0])
+        atom2 = Atom("C", [0.5, 0.0, 0.0])
+        atoms = [atom1, atom2]
+
+        # Use new min/max format
+        bond_cut = {"CC": {"min": 1.0, "max": 3.0}}
+        structure = Structure(lattice, atoms, bond_cut=bond_cut)
+
+        # Assert bond_mat is not None
+        assert structure.bond_mat is not None
+        assert isinstance(structure.bond_mat, np.ndarray)
+
+
+class TestBondCutoffLower:
+    """Test lower cutoff exclusion"""
+
+    def test_lower_cutoff_exclusion(self):
+        """AC3: Bonds with distance < min_cutoff are excluded from bond_mat"""
+        lattice_matrix = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
+        lattice = Lattice(lattice_matrix, 3.0)
+
+        # Two atoms at distance 1.5 angstroms (0.5 in fractional coords * 3.0 lattice constant)
+        atom1 = Atom("C", [0.0, 0.0, 0.0])
+        atom2 = Atom("C", [0.5, 0.0, 0.0])
+        atoms = [atom1, atom2]
+
+        # Set min cutoff to 2.0, so bonds with distance 1.5 should be excluded
+        bond_cut = {"CC": {"min": 2.0, "max": 3.0}}
+        structure = Structure(lattice, atoms, bond_cut=bond_cut)
+
+        # No bonds should exist (distance 1.5 < min 2.0)
+        assert not np.any(structure.bond_mat == True)
+
+
+class TestBondCutoffUpper:
+    """Test upper cutoff still works"""
+
+    def test_upper_cutoff_exclusion(self):
+        """AC4: Bonds with distance >= max_cutoff are excluded from bond_mat"""
+        lattice_matrix = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
+        lattice = Lattice(lattice_matrix, 3.0)
+
+        # Two atoms at distance 1.5 angstroms
+        atom1 = Atom("C", [0.0, 0.0, 0.0])
+        atom2 = Atom("C", [0.5, 0.0, 0.0])
+        atoms = [atom1, atom2]
+
+        # Set max cutoff to 1.0, so bonds with distance 1.5 should be excluded
+        bond_cut = {"CC": {"max": 1.0}}
+        structure = Structure(lattice, atoms, bond_cut=bond_cut)
+
+        # No bonds should exist (distance 1.5 >= max 1.0)
+        assert not np.any(structure.bond_mat == True)
+
+
+class TestBondCutoffSelfExclusion:
+    """Test self-exclusion preserved"""
+
+    def test_self_exclusion(self):
+        """AC5: Atoms exclude themselves (distance = 0) regardless of min value"""
+        lattice_matrix = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
+        lattice = Lattice(lattice_matrix, 3.0)
+
+        # Two atoms at same position (distance = 0)
+        atom1 = Atom("C", [0.0, 0.0, 0.0])
+        atom2 = Atom("C", [0.0, 0.0, 0.0])
+        atoms = [atom1, atom2]
+
+        # Set min to 0 (which would include distance 0 if not handled)
+        bond_cut = {"CC": {"min": 0, "max": 5.0}}
+        structure = Structure(lattice, atoms, bond_cut=bond_cut)
+
+        # Get distance matrix to find where distance is exactly 0
+        dist_mat = structure.dist_mat
+
+        # For all positions where distance is 0, bond_mat should be False
+        zero_dist_mask = dist_mat == 0
+        # All bonds at zero distance should be excluded
+        assert not np.any(structure.bond_mat[zero_dist_mask]), (
+            "Bonds found at zero distance (self-bonds)"
+        )
+
+
+class TestBondCutoffRangeInclusion:
+    """Test range inclusion works"""
+
+    def test_range_inclusion(self):
+        """AC6: Bonds within min <= distance < max are included"""
+        lattice_matrix = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
+        lattice = Lattice(lattice_matrix, 3.0)
+
+        # Two atoms at distance 1.5 angstroms
+        atom1 = Atom("C", [0.0, 0.0, 0.0])
+        atom2 = Atom("C", [0.5, 0.0, 0.0])
+        atoms = [atom1, atom2]
+
+        # Set range 1.0 to 3.0, so bonds with distance 1.5 should be included
+        bond_cut = {"CC": {"min": 1.0, "max": 3.0}}
+        structure = Structure(lattice, atoms, bond_cut=bond_cut)
+
+        # Bonds should exist (1.0 <= 1.5 < 3.0)
+        assert np.any(structure.bond_mat == True)


### PR DESCRIPTION
$(cat <<EOF
## Summary
- Extend `get_bond_mat()` to support min/max distance cutoffs for bond selection
- Maintain full backward compatibility with existing `{"NN": value}` format
- Add `get_min_max()` helper to handle both legacy and new `{"min": x, "max": y}` formats
- Update docstrings for `Structure.__init__` and `get_bond_mat()` methods

## Changes
- `pysktb/structure/structure.py`: Modified `get_bond_mat()` to accept min/max cutoffs
- `pysktb/structure/structure.py`: Added `get_min_max()` helper function
- Updated docstrings to document new cutoff parameter format
- Bond inclusion now uses half-open interval `[min, max)` as specified

## Test plan
- All 6 acceptance criteria tests pass
- Verified backward compatibility with `{"NN": value}` format
- Verified new `{"min": x, "max": y}` format works correctly
- Confirmed self-exclusion preserved via `dist_mat > 0` mask
- Run tests: `pytest tests/ -v`

Resolves #6

🤖 Built with [AgentField SWE-AF](https://github.com/Agent-Field/SWE-AF)
🔌 Powered by [AgentField](https://github.com/Agent-Field/agentfield)
EOF
)

---

<details><summary>📋 PRD (Product Requirements Document)</summary>

# PRD: Add Lower and Upper Cutoff for bond_mat

## Problem Statement
The `get_bond_mat()` method in `pysktb/structure.py` currently only supports a single cutoff value (`NN` - nearest neighbor distance). This limits users to including all bonds below a certain distance threshold, with no ability to exclude very short bonds (e.g., to exclude self-interactions or first-nearest neighbors when studying higher-order interactions).

## Current State Analysis
- **File**: `pysktb/structure.py`
- **Method**: `get_bond_mat()` (lines 58-94)
- **Current behavior**: Only checks `dist_mat[image_i, i, j] < cutoff` where `cutoff` comes from `bond_cut[pair]["NN"]`
- **Bond matrix shape**: `(max_image, n_atom, n_atom)` boolean array

## Proposed Solution
Extend the `bond_cut` dictionary format to optionally support both `min` and `max` (or `NN`) keys for each element pair. Maintain backward compatibility with the existing `"NN"` key format.

### Interface Changes

#### Option 1: New keys (backward compatible)
```python
bond_cut = {
    "CC": {"min": 1.0, "max": 3.0}  # New format
    # or
    "CC": {"NN": 3.0}  # Existing format (unchanged behavior)
}
```

The `get_cutoff()` nested function in `get_bond_mat()` should be modified to return a dict with `min` and `max` values:
- If only `"NN"` is provided: `min=0`, `max=NN_value`
- If `"min"` and `"max"` are provided: use those values
- If `"min"` is provided without `"max"`: raise error or default `max` to infinity

### Acceptance Criteria

#### AC1: Backward Compatibility
**Criterion**: Existing code using `{"XX": {"NN": value}}` format continues to work unchanged.
**Test**: 
```python
from pysktb import Lattice, Atom, Structure
lattice = Lattice([[1, 0, 0], [0, 1, 0], [0, 0, 1]], a=2.0)
atom = Atom("C", [0, 0, 0], orbitals=["s"])
structure = Structure(lattice, [atom], bond_cut={"CC": {"NN": 3.0}})
assert structure.bond_mat is not None
assert structure.bond_mat.shape == (structure.max_image, 1, 1)
```

#### AC2: New min/max Format Support
**Criterion**: `bond_cut` accepts `{"XX": {"min": lower, "max": upper}}` format.
**Test**:
```python
bond_cut = {"CC": {"min": 1.0, "max": 3.0}}
structure = Structure(lattice, [atom], bond_cut=bond_cut)
assert structure.bond_mat is not None
```

#### AC3: Lower Cutoff Exclusion
**Criterion**: Bonds with distance < min_cutoff are excluded from bond_mat.
**Test**:
```python
# Two atoms at distance 1.5 Angstroms
lattice = Lattice([[3, 0, 0], [0, 3, 0], [0, 0, 3]], a=1.0)
atom1 = Atom("C", [0, 0, 0], orbitals=["s"])
atom2 = Atom("C", [0.5, 0, 0], orbitals=["s"])  # Distance = 1.5

# With min=1.0, max=3.0 - bond should be included
structure = Structure(lattice, [atom1, atom2], bond_cut={"CC": {"min": 1.0, "max": 3.0}})
dist_mat = structure.dist_mat
# Verify bonds exist within range
has_bonds = np.any(structure.bond_mat)
assert has_bonds, "Bonds should exist for distances between min and max"

# With min=2.0 - bond should be excluded (distance 1.5 < 2.0)
structure2 = Structure(lattice, [atom1, atom2], bond_cut={"CC": {"min": 2.0, "max": 3.0}})
has_bonds2 = np.any(structure2.bond_mat)
assert not has_bonds2, "Bonds should be excluded when distance < min"
```

#### AC4: Upper Cutoff Still Works (max/NN)
**Criterion**: Bonds with distance >= max_cutoff are excluded from bond_mat.
**Test**:
```python
# Same setup as AC3
# With max=1.0 - bond should be excluded (distance 1.5 >= 1.0)
structure3 = Structure(lattice, [atom1, atom2], bond_cut={"CC": {"max": 1.0}})
has_bonds3 = np.any(structure3.bond_mat)
assert not has_bonds3, "Bonds should be excluded when distance >= max"
```

#### AC5: Self-Exclusion Still Works
**Criterion**: Atoms still exclude themselves (distance = 0).
**Test**:
```python
structure = Structure(lattice, [atom1], bond_cut={"CC": {"min": 0, "max": 5.0}})
# Bond matrix for single atom should be all False (no self-bond)
assert not np.any(structure.bond_mat), "Self-bonds should always be excluded"
```

#### AC6: Documentation Update
**Criterion**: Docstrings and type hints are updated to reflect the new parameter format.
**Test**: 
```bash
grep -A 10 "bond_cut" /workspaces/pysktb/pysktb/structure.py | grep -E "(min|max|NN)"
```

## Scope

### Must Have (P0)
1. Modify `get_bond_mat()` in `pysktb/structure.py` to support `min` parameter
2. Maintain backward compatibility with existing `"NN"` key
3. Update `Structure.__init__` docstring if present
4. Update method docstring for `get_bond_mat()`

### Nice to Have (P1)
1. Type hints for `bond_cut` parameter
2. Validation that min < max
3. Support for `max` as alias to `NN` in new format
4. Example in docstring showing min/max usage

### Out of Scope (Explicitly Excluded)
1. Changes to other files (hamiltonian.py, forces.py, etc.) - they consume bond_mat as-is
2. Changes to visualization bond handling
3. Changes to System class
4. Adding new bond_cut formats beyond min/max/NN
5. Performance optimization

## Assumptions
1. `min` value should default to 0 when not specified (backward compatible)
2. `max` and `NN` are equivalent - both represent the upper cutoff
3. When both `min` and `max` are specified, bond is included if `min <= distance < max` (half-open interval at upper bound)
4. Self-bonds (distance = 0) should always be excluded regardless of min value
5. Input validation is minimal; users are expected to provide sensible min/max values

## Risks

| Risk | Impact | Mitigation |
|------|--------|------------|
| Breaking existing code using bond_cut | High | Maintain full backward compatibility with "NN" key |
| Confusion between max and NN keys | Medium | Document that they are equivalent; prefer "max" in new code |
| Invalid min/max values (min >= max) | Low | Add simple validation or let it result in empty bond_mat |
| Performance regression from additional comparison | Low | The change adds one comparison per pair; negligible overhead |

## Implementation Notes

### Current Logic (simplified):
```python
for image_i, image in enumerate(itertools.product(*periodic_image)):
    for i, atom1 in enumerate(atoms):
        for j, atom2 in enumerate(atoms):
            cutoff = get_cutoff(atom1, atom2)["NN"]
            if cutoff is None:
                continue
            bond_mat[image_i, i, j] = dist_mat[image_i, i, j] < cutoff
bond_mat_2 = dist_mat > 0
return bond_mat * bond_mat_2
```

### New Logic:
```python
for image_i, image in enumerate(itertools.product(*periodic_image)):
    for i, atom1 in enumerate(atoms):
        for j, atom2 in enumerate(atoms):
            cutoffs = get_cutoff(atom1, atom2)
            if cutoffs is None:
                continue
            min_cut = cutoffs.get("min", 0)
            max_cut = cutoffs.get("max") or cutoffs.get("NN")
            if max_cut is None:
                continue
            dist = dist_mat[image_i, i, j]
            bond_mat[image_i, i, j] = (min_cut <= dist < max_cut)
bond_mat_2 = dist_mat > 0
return bond_mat * bond_mat_2
```

## Success Metrics
1. All existing tests (if any) pass
2. New acceptance criteria tests pass
3. No breaking changes to public API
4. Documentation accurately describes new functionality


</details>

<details><summary>🏗️ Architecture</summary>

# Architecture: Extend bond_mat() with Min/Max Cutoff Support

## Summary
Extend `pysktb/structure.py::Structure.get_bond_mat()` to support both lower (`min`) and upper (`max`/`NN`) distance cutoffs for bond matrix generation. The bond_cut dictionary will accept either the existing `{"XX": {"NN": value}}` format or a new `{"XX": {"min": lower, "max": upper}}` format. Bonds are included when `min <= distance < max`. Full backward compatibility maintained.

## Components

### Component: Bond Cutoff Parser
**Responsibility**: Parse bond_cut dictionary entries and normalize to min/max values
**Touches Files**: pysktb/structure.py (get_bond_mat method)
**Depends On**: None

### Component: Bond Matrix Generator
**Responsibility**: Generate boolean bond matrix using min/max cutoffs, maintain self-exclusion
**Touches Files**: pysktb/structure.py (get_bond_mat method)
**Depends On**: Bond Cutoff Parser

## Interfaces

### get_cutoff() - Internal Helper Function
```python
def get_cutoff(atom_1: Atom, atom_2: Atom) -> Optional[Dict[str, float]]:
    """
    Retrieve bond cutoff configuration for an atom pair.
    
    Args:
        atom_1: First atom
        atom_2: Second atom
        
    Returns:
        Dict with keys "min" and "max" (both floats), or None if no cutoff defined.
        For backward compatibility, if input has "NN" key, min defaults to 0.
    """
```

### bond_cut Parameter Format
```python
# Type union for bond_cut values
BondCutValue = Union[
    Dict[str, float],  # {"NN": float} or {"min": float, "max": float}
]

# Full bond_cut type
BondCutConfig = Dict[str, BondCutValue]

# Examples:
# Backward compatible: {"CC": {"NN": 3.0}}
# New format: {"CC": {"min": 1.0, "max": 3.0}}
```

## Decisions

### Decision: Normalize to min/max internally
**Rationale**: Converting all formats to a normalized min/max representation at the parsing stage simplifies the bond inclusion logic. The bond inclusion check becomes a single expression: `min <= dist < max` regardless of input format.

### Decision: Support both "max" and "NN" as upper cutoff keys
**Rationale**: "NN" is the existing key name. Supporting "max" as an alias in the new format provides clearer semantics while maintaining backward compatibility. If both are present, "max" takes precedence.

### Decision: Default min to 0 when not specified
**Rationale**: This maintains backward compatibility with existing `{"NN": value}` format. Users who don't specify min get the previous behavior of including all bonds from 0 up to the cutoff.

### Decision: Self-exclusion via dist_mat > 0 check preserved
**Rationale**: The existing code uses `bond_mat_2 = dist_mat > 0` as a final mask. This approach is preserved because it handles all edge cases (self-exclusion, zero-distance artifacts) in one operation, regardless of min value.

### Decision: Bond inclusion uses half-open interval [min, max)
**Rationale**: This is consistent with the existing `< cutoff` behavior. The upper bound is exclusive to avoid double-counting at exact cutoff distances across periodic boundaries.

## File Changes Overview

### pysktb/structure.py
**Lines 58-94**: Modify `get_bond_mat()` method

**Current Logic**:
```python
cutoff = get_cutoff(atom1, atom2)["NN"]
if cutoff is None:
    continue
bond_mat[image_i, i, j] = dist_mat[image_i, i, j] < cutoff
```

**New Logic**:
```python
cutoffs = get_cutoff(atom1, atom2)
if cutoffs is None:
    continue
min_cut = cutoffs.get("min", 0.0)
max_cut = cutoffs.get("max") or cutoffs.get("NN")
if max_cut is None:
    continue
dist = dist_mat[image_i, i, j]
bond_mat[image_i, i, j] = (min_cut <= dist < max_cut)
```

**Key Changes**:
1. Modify `get_cutoff()` nested function to return the full cutoff dict instead of just accessing `["NN"]`
2. Parse `min` and `max`/`NN` values with appropriate defaults
3. Update bond inclusion condition to check `min <= dist < max`
4. Update docstrings to document new min/max parameters

**Data Flow Example**:
```
Input: bond_cut = {"CC": {"min": 1.0, "max": 3.0}}

Processing:
  - get_cutoff(atom_C, atom_C) returns {"min": 1.0, "max": 3.0}
  - For atom pair with dist = 1.5:
    - min_cut = 1.0, max_cut = 3.0
    - Check: 1.0 <= 1.5 < 3.0 → True
    - bond_mat[image, i, j] = True
  - For atom pair with dist = 0.5:
    - Check: 1.0 <= 0.5 < 3.0 → False
    - bond_mat[image, i, j] = False
  - For atom pair with dist = 3.0:
    - Check: 1.0 <= 3.0 < 3.0 → False (upper bound exclusive)
    - bond_mat[image, i, j] = False

Final: bond_mat *= (dist_mat > 0)  # Preserves self-exclusion
```

**Backward Compatibility**:
- Input: `{"CC": {"NN": 3.0}}` works unchanged
- Processing: min defaults to 0.0, max taken from "NN"
- Result: Same behavior as before

## Error Handling

### Invalid Bond Cutoff Configurations
- **Missing both max and NN**: Skip bond pair (return False for all distances)
- **Negative min value**: Accepted (though unusual, may be used for exotic cases)
- **min >= max**: Results in empty bond_mat for that pair (no error raised)

### Type Safety
- bond_cut parameter is Optional[Dict[str, Dict[str, float]]]
- Individual cutoff values should be numeric (int or float)
- get_cutoff returns Optional[Dict[str, float]] with guaranteed "min" and "max" keys when not None


</details>
